### PR TITLE
Potential fix for code scanning alert no. 3: Wrong type of arguments to formatting function

### DIFF
--- a/src/alloc/SlabAllocator.cpp
+++ b/src/alloc/SlabAllocator.cpp
@@ -333,7 +333,7 @@ SlabAllocator::~SlabAllocator() {
 				freeBlocks += countSetBits(chunk->freeBlocks[i]);
 			int allocatedBlocks = chunk->numBlocks - freeBlocks;
 			if (allocatedBlocks > 0)
-				dprintf(2, "  Chunk %i: %i blocks of size %i\n", chunkId, allocatedBlocks, chunk->blockWidth);
+				dprintf(2, "  Chunk %i: %i blocks of size %lu\n", chunkId, allocatedBlocks, chunk->blockWidth);
 		}
 		::free(chunk->blocks);
 #ifndef DEBUG_MEMORY

--- a/src/strutil.cpp
+++ b/src/strutil.cpp
@@ -47,7 +47,7 @@ char* formatBinaryDataForHexdump(const uint8_t* data, int size, int columns) {
 
 	for (int line = 0; line < nLines; line++) {
 		if (nLines > 1)
-			p += sprintf(p, "%04x  ", dp - data);
+			p += sprintf(p, "%04zx  ", (size_t)(dp - data));
 
 		if (line + 1 == nLines)
 			columns = size - columns * line;


### PR DESCRIPTION
Potential fix for [https://github.com/komozoi/libexcessive/security/code-scanning/3](https://github.com/komozoi/libexcessive/security/code-scanning/3)

The fix is to make the format specifier for `chunk->blockWidth` match its actual type.

Best minimal fix (no behavior change except correct formatting): in `src/alloc/SlabAllocator.cpp`, line 336’s format string should use `%lu` for `unsigned long` instead of `%i`.

No new methods, definitions, or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
